### PR TITLE
use aws credentials from environment variables

### DIFF
--- a/docs/Plugins/Route53.md
+++ b/docs/Plugins/Route53.md
@@ -142,3 +142,7 @@ When using an IAM Role, the only thing you need to specify is a switch called `R
 ```powershell
 New-PACertificate example.com -Plugin Route53 -PluginArgs @{R53UseIAMRole=$true}
 ```
+
+### Use Environment Variables
+
+If no other credential sources are found, the plugin will attempt to use environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`


### PR DESCRIPTION
If no other credentials are set we'll attempt to use environment variables for AWS credentials when using Route53.

We'll attempt to use AWS_SESSION_TOKEN only if it's also set.